### PR TITLE
fix texture drawing when no sky or floor visible

### DIFF
--- a/src/walls/textures.c
+++ b/src/walls/textures.c
@@ -37,6 +37,8 @@ int	texture_x_value(mlx_texture_t *tex, t_vector *target, t_direction direction)
 int	texture_y_value(mlx_texture_t *tex, int line_height, int window_y,
 		int start)
 {
+	if (line_height >= HEIGHT)
+		start = start - ((line_height - HEIGHT) / 2);
 	return ((window_y - start) * tex->height / line_height);
 }
 


### PR DESCRIPTION
textures have been distorted when drawn without ceiling or floor visible in the line